### PR TITLE
Prevent workflow version from bad update (#6848)

### DIFF
--- a/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-query-hook.module.ts
+++ b/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-query-hook.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+
+import { WorkflowVersionUpdateOnePreQueryHook } from 'src/modules/workflow/common/query-hooks/workflow-version/workflow-version-update-one.pre-query-hook';
+import { WorkflowVersionValidationWorkspaceService } from 'src/modules/workflow/common/query-hooks/workflow-version/workflow-version-validation.workspace-service';
+import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workflow-common.workspace-service';
+
+@Module({
+  providers: [
+    WorkflowVersionUpdateOnePreQueryHook,
+    WorkflowVersionValidationWorkspaceService,
+    WorkflowCommonWorkspaceService,
+  ],
+})
+export class WorkflowQueryHookModule {}

--- a/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-version/workflow-version-update-one.pre-query-hook.ts
+++ b/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-version/workflow-version-update-one.pre-query-hook.ts
@@ -1,0 +1,28 @@
+import { WorkspaceQueryHookInstance } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/interfaces/workspace-query-hook.interface';
+import { UpdateOneResolverArgs } from 'src/engine/api/graphql/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
+
+import { WorkspaceQueryHook } from 'src/engine/api/graphql/workspace-query-runner/workspace-query-hook/decorators/workspace-query-hook.decorator';
+import { AuthContext } from 'src/engine/core-modules/auth/types/auth-context.type';
+import { WorkflowVersionValidationWorkspaceService } from 'src/modules/workflow/common/query-hooks/workflow-version/workflow-version-validation.workspace-service';
+import { WorkflowVersionWorkspaceEntity } from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
+
+@WorkspaceQueryHook(`workflowVersion.updateOne`)
+export class WorkflowVersionUpdateOnePreQueryHook
+  implements WorkspaceQueryHookInstance
+{
+  constructor(
+    private readonly workflowVersionValidationWorkspaceService: WorkflowVersionValidationWorkspaceService,
+  ) {}
+
+  async execute(
+    _authContext: AuthContext,
+    _objectName: string,
+    payload: UpdateOneResolverArgs<WorkflowVersionWorkspaceEntity>,
+  ): Promise<UpdateOneResolverArgs<WorkflowVersionWorkspaceEntity>> {
+    await this.workflowVersionValidationWorkspaceService.validateWorkflowVersionForUpdateOne(
+      payload,
+    );
+
+    return payload;
+  }
+}

--- a/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-version/workflow-version-validation.exception.ts
+++ b/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-version/workflow-version-validation.exception.ts
@@ -1,0 +1,11 @@
+import { CustomException } from 'src/utils/custom-exception';
+
+export class WorkflowVersionValidationException extends CustomException {
+  constructor(message: string, code: WorkflowVersionValidationExceptionCode) {
+    super(message, code);
+  }
+}
+
+export enum WorkflowVersionValidationExceptionCode {
+  FORBIDDEN = 'FORBIDDEN',
+}

--- a/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-version/workflow-version-validation.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/query-hooks/workflow-version/workflow-version-validation.workspace-service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+
+import { UpdateOneResolverArgs } from 'src/engine/api/graphql/workspace-resolver-builder/interfaces/workspace-resolvers-builder.interface';
+
+import {
+  WorkflowVersionValidationException,
+  WorkflowVersionValidationExceptionCode,
+} from 'src/modules/workflow/common/query-hooks/workflow-version/workflow-version-validation.exception';
+import {
+  WorkflowVersionStatus,
+  WorkflowVersionWorkspaceEntity,
+} from 'src/modules/workflow/common/standard-objects/workflow-version.workspace-entity';
+import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workflow-common.workspace-service';
+
+@Injectable()
+export class WorkflowVersionValidationWorkspaceService {
+  constructor(
+    private readonly workflowCommonWorkspaceService: WorkflowCommonWorkspaceService,
+  ) {}
+
+  async validateWorkflowVersionForUpdateOne(
+    payload: UpdateOneResolverArgs<WorkflowVersionWorkspaceEntity>,
+  ) {
+    const workflowVersion =
+      await this.workflowCommonWorkspaceService.getWorkflowVersionOrFail(
+        payload.id,
+      );
+
+    if (workflowVersion.status !== WorkflowVersionStatus.DRAFT) {
+      throw new WorkflowVersionValidationException(
+        'Only draft workflow versions can be updated',
+        WorkflowVersionValidationExceptionCode.FORBIDDEN,
+      );
+    }
+
+    if (payload.data.status !== workflowVersion.status) {
+      throw new WorkflowVersionValidationException(
+        'Cannot update workflow version status manually',
+        WorkflowVersionValidationExceptionCode.FORBIDDEN,
+      );
+    }
+  }
+}

--- a/packages/twenty-server/src/modules/workflow/common/workflow-common.module.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workflow-common.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 
+import { WorkflowQueryHookModule } from 'src/modules/workflow/common/query-hooks/workflow-query-hook.module';
 import { WorkflowCommonWorkspaceService } from 'src/modules/workflow/common/workflow-common.workspace-service';
 
 @Module({
+  imports: [WorkflowQueryHookModule],
   providers: [WorkflowCommonWorkspaceService],
   exports: [WorkflowCommonWorkspaceService],
 })

--- a/packages/twenty-server/src/modules/workflow/common/workflow-common.workspace-service.ts
+++ b/packages/twenty-server/src/modules/workflow/common/workflow-common.workspace-service.ts
@@ -17,6 +17,13 @@ export class WorkflowCommonWorkspaceService {
       trigger: WorkflowTrigger;
     }
   > {
+    if (!workflowVersionId) {
+      throw new WorkflowTriggerException(
+        'Workflow version ID is required',
+        WorkflowTriggerExceptionCode.INVALID_INPUT,
+      );
+    }
+
     const workflowVersionRepository =
       await this.twentyORMManager.getRepository<WorkflowVersionWorkspaceEntity>(
         'workflowVersion',


### PR DESCRIPTION
Closes https://github.com/twentyhq/twenty/issues/6840

- Add query-hooks folder in common. Will be followed by hooks for workflows and runs
- When updating a version, ensure the status is draft and that the status is not manually updated